### PR TITLE
Prevent ships from touching and add adjacency tests

### DIFF
--- a/src/model.js
+++ b/src/model.js
@@ -43,8 +43,16 @@ export class BoardModel {
       const ii = i + (dir === 'h' ? k : 0);
       const jj = j + (dir === 'v' ? k : 0);
       if (!this.inBounds(ii, jj)) return false;
-      if (this.grid[jj][ii] !== CELL.Empty) return false;
-      // Optional: Randregel (keine Berührung) – später einbauen
+
+      // Prüfe Zelle sowie alle Nachbarn (inkl. Diagonalen) auf Leerheit
+      for (let di = -1; di <= 1; di++) {
+        for (let dj = -1; dj <= 1; dj++) {
+          const ni = ii + di;
+          const nj = jj + dj;
+          if (!this.inBounds(ni, nj)) continue;
+          if (this.grid[nj][ni] !== CELL.Empty) return false;
+        }
+      }
     }
     return true;
   }

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { BoardModel, ShipType } from '../src/model.js';
+
+test('cannot place ships adjacent horizontally', () => {
+  const board = new BoardModel();
+  const ship = new ShipType('Destroyer', 2);
+  assert.strictEqual(board.placeShip(ship, 0, 0, 'h'), true);
+  assert.strictEqual(board.canPlaceShip(2, 0, ship.length, 'h'), false);
+  assert.strictEqual(board.placeShip(ship, 2, 0, 'h'), false);
+});
+
+test('cannot place ships adjacent vertically', () => {
+  const board = new BoardModel();
+  const ship = new ShipType('Destroyer', 2);
+  assert.strictEqual(board.placeShip(ship, 0, 0, 'h'), true);
+  assert.strictEqual(board.canPlaceShip(0, 1, ship.length, 'v'), false);
+  assert.strictEqual(board.placeShip(ship, 0, 1, 'v'), false);
+});
+
+test('cannot place ships adjacent diagonally', () => {
+  const board = new BoardModel();
+  const ship = new ShipType('Destroyer', 2);
+  assert.strictEqual(board.placeShip(ship, 0, 0, 'h'), true);
+  assert.strictEqual(board.canPlaceShip(1, 1, ship.length, 'h'), false);
+  assert.strictEqual(board.placeShip(ship, 1, 1, 'h'), false);
+});


### PR DESCRIPTION
## Summary
- Ensure `canPlaceShip` rejects placements touching existing ships, including diagonal neighbors
- Add tests verifying that horizontal, vertical, and diagonal adjacency is blocked

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a5eaef2d0c832ea4252ca276524588