### PR TITLE
Dispose ghost objects before clearing

### DIFF
--- a/src/board.js
+++ b/src/board.js
@@ -162,7 +162,16 @@ export class Board extends THREE.Group {
     }
   }
 
-  clearGhost() { this.ghostGroup.clear(); }
+  clearGhost() {
+    for (const child of this.ghostGroup.children) {
+      if (child.geometry) child.geometry.dispose();
+      if (child.material) {
+        if (Array.isArray(child.material)) child.material.forEach(m => m.dispose());
+        else child.material.dispose();
+      }
+    }
+    this.ghostGroup.clear();
+  }
 
   placeShipVisual(cells) {
     const mat = new THREE.MeshBasicMaterial({ color: 0x3399ff, transparent: true, opacity: 0.65, side: THREE.DoubleSide });


### PR DESCRIPTION
## Summary
- Dispose geometry and materials for ghost preview tiles before clearing the ghost group to free GPU resources

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5ed3f3a08832eb43f2275a9a573a8