### PR TITLE
Handle WebSocket closure

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -487,6 +487,7 @@ async function startMP(asHost) {
   });
   mp.addEventListener('message', (e) => onMPMessage(e.detail));
   mp.addEventListener('error', (e) => { mpStatus.textContent = `Fehler: ${e.detail?.reason || 'unbekannt'}`; });
+  mp.addEventListener('ws_close', () => { stopMP(); mpStatus.textContent = 'WebSocket geschlossen.'; });
 
   try {
     await mp.connect(url, room);

--- a/src/net.js
+++ b/src/net.js
@@ -17,6 +17,7 @@ export class MPClient extends EventTarget {
         this.wsSend({ type: 'join', room: roomId });
       };
       this.ws.onerror = (e) => this.dispatch('error', { reason: 'ws_error', e });
+      this.ws.onclose = () => { this.dispatch('ws_close', {}); this.closePeer(); };
 
       this.ws.onmessage = async (ev) => {
         let msg; try { msg = JSON.parse(ev.data); } catch { return; }


### PR DESCRIPTION
## Summary
- Dispatch a `ws_close` event when the signaling socket closes and clean up the peer connection
- Respond to `ws_close` in the UI, showing a status message and releasing resources

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a6093a8e24832ea6a7ff9ab6618272