### PR TITLE
Use cached reference space for AR hit test

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -328,7 +328,7 @@ function render(_, frame) {
   if (frame && hitTestSource && !boardPlayer && !boardAI) {
     const hits = frame.getHitTestResults(hitTestSource);
     if (hits?.length) {
-      const pose = hits[0].getPose(renderer.xr.getReferenceSpace());
+      const pose = hits[0].getPose(referenceSpace);
       if (pose) {
         reticle.visible = true;
         reticle.position.set(pose.transform.position.x, pose.transform.position.y, pose.transform.position.z);


### PR DESCRIPTION
## Summary
- Use pre-fetched `referenceSpace` for AR hit-test pose
- Ensure reference space is requested during session start

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a89150ccc4832e91cdb43a4cc704c5