### PR TITLE
Use local-floor reference space

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -218,6 +218,7 @@ async function init() {
   renderer.setPixelRatio(window.devicePixelRatio);
   renderer.setSize(window.innerWidth, window.innerHeight);
   renderer.xr.enabled = true;
+  renderer.xr.setReferenceSpaceType('local-floor');
   document.body.appendChild(renderer.domElement);
 
   scene.add(new THREE.HemisphereLight(0xffffff, 0x444444, 1.0));
@@ -313,7 +314,7 @@ function onWindowResize(){ camera.aspect=window.innerWidth/window.innerHeight; c
 
 async function onSessionStart(){
   const session = renderer.xr.getSession();
-  referenceSpace = await session.requestReferenceSpace('local');
+  referenceSpace = await session.requestReferenceSpace('local-floor');
   viewerSpace = await session.requestReferenceSpace('viewer');
   hitTestSource = await session.requestHitTestSource?.({ space: viewerSpace });
 }


### PR DESCRIPTION
## Summary
- Switch XR session reference space to `local-floor`
- Set renderer to use `local-floor` reference space before sessions start

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a892072a50832e9320e312f7c568a7