### PR TITLE
Add board repositioning mode via UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,7 @@
     <small id="mpStatus">Offline</small>
   </div>
 
+  <button id="btnReposition" class="btn" type="button" style="right:292px;">Brett verschieben</button>
   <button id="btnAudio" class="btn" type="button">🔊 SFX an</button>
   <button id="btnReset" class="btn" type="button">Neustart</button>
 


### PR DESCRIPTION
## Summary
- add reposition button to reattach boards to the reticle for relocation
- implement reticle-bound movement and re-anchoring while preserving ships and shots
- ignore gameplay actions while moving and reset mode on game reset

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68a8c4e95ec4832e8f18090c86e96bee